### PR TITLE
remove python and aptitude prerequisite

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: gather facts
+  setup:
+
 - name: Perform Safe Upgrade
   apt: upgrade=safe update_cache=yes
 

--- a/site.yml
+++ b/site.yml
@@ -8,7 +8,13 @@
   # remote_user: deploy
   # become: yes
   # become_method: sudo
-
+  pre_tasks:
+    - name: apt-get update
+      raw: apt-get update -qq
+    - name: install python 2.7 and aptitude
+      raw: apt-get install -qq python2.7 aptitude
+    - name: set python 2.7 as default
+      raw: update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
   roles:
     - common
     - deploy-user

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,7 @@
   # remote_user: deploy
   # become: yes
   # become_method: sudo
+  gather_facts: no # don't gather facts because /usr/bin/python isn't set
   pre_tasks:
     - name: apt-get update
       raw: apt-get update -qq


### PR DESCRIPTION
I saw in the documentation that installing python and aptitude is the first prerequisite to using this playbook. I've used the pre_tasks in the commit for awhile on Ubuntu and they seem to be reliable. 