### PR TITLE
Corrects forwarded protocol on non-HTTPS Nginx config to HTTP

### DIFF
--- a/roles/nginx/templates/nginx_app_config
+++ b/roles/nginx/templates/nginx_app_config
@@ -17,7 +17,7 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto http;
     proxy_pass http://puma_production;
 
     access_log {{ deploy_dir  }}{{ deploy_app_name }}/shared/log/nginx.access.log;


### PR DESCRIPTION
Had some issues after spinning up a local Vagrant instance provisioned with these Ansible tasks. The instance was set up for plain HTTP, and I started getting CSRF token errors from Rails. Took a while to realize this was because Rails [compares](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L422) the `request.base_url` with the `Origin` header, origin was `http://` while header was `https://`, due to the header protocol here being https.

Since this config file is for plain http, it should use that for the `X-Forwarded-Proto` header.