### PR TITLE
use unarchive module from Ansible

### DIFF
--- a/roles/ruby/tasks/chruby.yml
+++ b/roles/ruby/tasks/chruby.yml
@@ -1,14 +1,12 @@
 ---
 - name: Download chruby
-  get_url:
-    url: "https://github.com/postmodern/chruby/archive/v{{ chruby_version }}.tar.gz"
-    dest: /root/chruby.tar.gz
-
-- name: Unpack chruby
-  command: tar -xzvf /root/chruby.tar.gz
+  unarchive:
+    src: "https://github.com/postmodern/chruby/archive/v{{ chruby_version }}.tar.gz"
+    dest: /home/deploy/
+    remote_src: yes
 
 - name: Install chruby
-  make: chdir=/root/chruby-{{ chruby_version }} target=install
+  make: chdir=/home/deploy/chruby-{{ chruby_version }} target=install
 
 - name: Copy chruby.sh
   copy: src=chruby.sh dest=/etc/profile.d/chruby.sh owner=root group=root

--- a/roles/ruby/tasks/ruby-install.yml
+++ b/roles/ruby/tasks/ruby-install.yml
@@ -1,14 +1,12 @@
 ---
-- name: Download ruby-install
-  get_url:
-    url: "https://github.com/postmodern/ruby-install/archive/v{{ ruby_install_version }}.tar.gz"
-    dest: /root/ruby-install.tar.gz
-
-- name: Unpack ruby-install
-  command: tar -xzvf /root/ruby-install.tar.gz
+- name: Download and unpack ruby-install
+  unarchive:
+    src: "https://github.com/postmodern/ruby-install/archive/v{{ ruby_install_version }}.tar.gz"
+    dest: /home/deploy/
+    remote_src: yes
 
 - name: Install ruby-install
-  make: chdir=/root/ruby-install-{{ ruby_install_version }} target=install
+  make: chdir=/home/deploy/ruby-install-{{ ruby_install_version }} target=install
 
 - name: Create rubies directory
   file: path=/opt/rubies/ state=directory mode=0755 owner=root group=root


### PR DESCRIPTION
I think it makes sense to use dedicated Ansible modules whenever possible. As there is an `unarchive` module there ([see docs](http://docs.ansible.com/ansible/latest/modules/unarchive_module.html)), we might use it in our files as well.

The only thing I'm not sure of is where to store temp downloads: is `/root/` or `/home/deploy` a good solution.